### PR TITLE
chore: migrate Renovate preset to recommended

### DIFF
--- a/.github/renovate.json
+++ b/.github/renovate.json
@@ -1,6 +1,6 @@
 {
   "$schema": "https://docs.renovatebot.com/renovate-schema.json",
-  "extends": ["config:base", ":prHourlyLimitNone", ":semanticCommits"],
+  "extends": ["config:recommended", ":prHourlyLimitNone", ":semanticCommits"],
   "ignorePaths": ["html/**"],
   "prConcurrentLimit": 3,
   "lockFileMaintenance": {


### PR DESCRIPTION
## Summary
- Migrates Renovate from the deprecated `config:base` preset to `config:recommended`.
- Leaves the repo-specific limits, semantic commits, ignore paths, and lock-file maintenance settings unchanged.

## Why
The Renovate Dependency Dashboard currently reports **Config Migration Needed** (#331). This applies the documented preset migration directly so future dependency PRs can continue using a supported Renovate baseline.

## Verification
- `python3 -m json.tool .github/renovate.json`
- `git diff --check`

No package or generated source changes are included.