### PR TITLE
fix(ci): skip releases in pull request checks

### DIFF
--- a/.github/workflows/wa-update.yml
+++ b/.github/workflows/wa-update.yml
@@ -52,7 +52,7 @@ jobs:
         id: update
         run: npm run wa-update
         env:
-          WA_COMMIT: true
+          WA_COMMIT: ${{ github.event_name != 'pull_request' }}
 
       - name: Git Status
         if: ${{ steps.update.outputs.hasChanges == 'true' }}
@@ -63,7 +63,7 @@ jobs:
         run: git clean -fd
 
       - name: Release
-        if: ${{ steps.update.outputs.hasChanges == 'true' }}
+        if: ${{ steps.update.outputs.hasChanges == 'true' && github.event_name != 'pull_request' }}
         run: npm run release -- --ci -i patch
 
       - name: Discord Notification (Outdated)


### PR DESCRIPTION
## Summary
- keep wa-update detection active for pull requests
- disable WA_COMMIT during pull-request checks
- skip release-it publishing for pull-request events

## Why
After release-it v21, a pull-request run that detects a new WhatsApp version attempts to release from a detached HEAD and fails with fatal: ref HEAD is not a symbolic ref. Pull requests should validate update detection, not create commits or releases.

## Verification
- reproduced in wa-update run 31412844770
- workflow expression keeps push, schedule, and workflow_dispatch release behavior unchanged
- git diff --check