### PR TITLE
fix(ci): use GitHub token for pull request checks

### DIFF
--- a/.github/workflows/wa-update.yml
+++ b/.github/workflows/wa-update.yml
@@ -18,7 +18,7 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v6
         with:
-          token: ${{ secrets.PERSONAL_TOKEN }}
+          token: ${{ github.event_name == 'pull_request' && github.token || secrets.PERSONAL_TOKEN }}
 
       - name: Setup GIT
         run: |


### PR DESCRIPTION
## Summary
- use the ephemeral GitHub token when wa-update runs for pull requests
- keep PERSONAL_TOKEN for push, schedule, and manual release events

## Why
Dependabot pull requests cannot access repository secrets. The wa-update checkout therefore failed before running any project code with Input required and not supplied: token. Pull-request checks only need read access and must not publish; release events retain the credential used for commits and tags.

## Verification
- reproduced in wa-update runs 31413459532 and 31413471216
- pull requests already have WA_COMMIT disabled and Release skipped by #688
- git diff --check