### PR TITLE
fix(ci): complete Renovate config migration

### DIFF
--- a/.github/renovate.json
+++ b/.github/renovate.json
@@ -10,7 +10,7 @@
   "packageRules": [
     {
       "description": "Use bump strategy",
-      "matchPackagePatterns": ["*"],
+      "matchPackageNames": ["*"],
       "rangeStrategy": "bump",
       "semanticCommitType": "build",
       "labels": ["dependencies"]


### PR DESCRIPTION
## Summary
- replace deprecated matchPackagePatterns with matchPackageNames
- preserve the existing wildcard bump strategy

## Why
The Dependency Dashboard still reports Config Migration Needed after #673. Renovate's strict validator identifies this key rename as the remaining migration.

## Verification
- npx --yes --package renovate renovate-config-validator .github/renovate.json --strict
- git diff --check