### PR TITLE
fix(security): restrict workflow token permissions

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -8,6 +8,9 @@ on:
     branches:
       - '*'
 
+permissions:
+  contents: read
+
 jobs:
   build:
     runs-on: ubuntu-latest

--- a/.github/workflows/commitlint.yml
+++ b/.github/workflows/commitlint.yml
@@ -1,6 +1,10 @@
 name: commit lint
 on: [pull_request]
 
+permissions:
+  contents: read
+  pull-requests: read
+
 jobs:
   commitlint:
     runs-on: ubuntu-latest

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -8,6 +8,9 @@ on:
     branches:
       - '*'
 
+permissions:
+  contents: read
+
 jobs:
   lint:
     runs-on: ubuntu-latest

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -12,6 +12,10 @@ on:
           - patch
           - minor
           - major
+
+permissions:
+  contents: read
+
 jobs:
   release:
     runs-on: ubuntu-latest

--- a/.github/workflows/wa-update.yml
+++ b/.github/workflows/wa-update.yml
@@ -11,6 +11,9 @@ on:
   schedule:
     - cron: '5,35 * * * *'
 
+permissions:
+  contents: read
+
 jobs:
   wa-update:
     runs-on: ubuntu-latest


### PR DESCRIPTION
## Summary
- add explicit least-privilege GITHUB_TOKEN permissions to all workflows
- grant commitlint only the pull-request metadata access it requires
- keep release/update writes on the existing PERSONAL_TOKEN checkout credential

## Validation
- all workflow YAML files parse successfully
- git diff --check passes
- every workflow now has an explicit top-level permissions block

Closes the five open ctions/missing-workflow-permissions code-scanning findings.