### PR TITLE
fix(ci): serialize wa-update releases

### DIFF
--- a/.github/workflows/wa-update.yml
+++ b/.github/workflows/wa-update.yml
@@ -3,7 +3,7 @@ name: wa-update
 on:
   push:
     branches:
-      - '*'
+      - main
   pull_request:
     branches:
       - '*'
@@ -14,6 +14,10 @@ on:
 permissions:
   contents: read
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.event_name == 'pull_request' && github.event.pull_request.number || 'release' }}
+  cancel-in-progress: ${{ github.event_name == 'pull_request' }}
+
 jobs:
   wa-update:
     runs-on: ubuntu-latest
@@ -21,6 +25,7 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v7
         with:
+          ref: ${{ github.event_name == 'pull_request' && github.sha || 'main' }}
           token: ${{ github.event_name == 'pull_request' && github.token || secrets.PERSONAL_TOKEN }}
 
       - name: Setup GIT

--- a/.release-it.yml
+++ b/.release-it.yml
@@ -1,7 +1,9 @@
 git:
   commitMessage: 'chore(release): v${version}'
+  requireBranch: main
   tagAnnotation: 'chore(release): v${version}'
   tagName: 'v${version}'
+  pushArgs: ['--follow-tags', '--atomic']
 
 hooks:
   after:bump:


### PR DESCRIPTION
## Cause

Two `wa-update` runs started from consecutive `main` commits and both calculated `v1.5.4556`. The first push partially created the tag while its stale branch update was rejected; the second run then failed because that tag already existed.

## Fix

- run push-triggered updates only from `main`
- serialize release events while keeping PR checks independent
- checkout the latest `main` for release events
- require the `main` branch in release-it
- push the branch and tag atomically

## Validation

- `actionlint v1.7.12 .github/workflows/wa-update.yml`
- `npm ci`
- `npm run build`
- release-it dry-run emitted `git push --follow-tags --atomic`
- regression guard checks for main-only trigger, serialization, latest-main checkout, and atomic push

Local lint is affected by the Windows checkout converting tracked TypeScript files to CRLF; the PR's Linux lint check is the authoritative validation.