### PR TITLE
fix: stop losing versions and bumping without a new version

### DIFF
--- a/.github/workflows/wa-update.yml
+++ b/.github/workflows/wa-update.yml
@@ -71,12 +71,12 @@ jobs:
         run: git clean -fd
 
       - name: Release
-        if: ${{ steps.update.outputs.hasChanges == 'true' && github.event_name != 'pull_request' }}
+        if: ${{ steps.update.outputs.shouldRelease == 'true' && github.event_name != 'pull_request' }}
         run: npm run release -- --ci -i patch
 
       - name: Discord Notification (Outdated)
         uses: sarisia/actions-status-discord@v1
-        if: ${{ steps.update.outputs.hasOutdated == 'true' }}
+        if: ${{ steps.update.outputs.hasOutdated == 'true' && steps.update.outputs.shouldRelease == 'true' }}
         with:
           webhook: ${{ secrets.DISCORD_WEBHOOK }}
           nodetail: true

--- a/.github/workflows/wa-update.yml
+++ b/.github/workflows/wa-update.yml
@@ -9,7 +9,7 @@ on:
       - '*'
   workflow_dispatch:
   schedule:
-    - cron: '5,35 * * * *'
+    - cron: '5 * * * *'
 
 permissions:
   contents: read

--- a/src/fetchCurrentAlphaVersion.ts
+++ b/src/fetchCurrentAlphaVersion.ts
@@ -18,6 +18,21 @@ import fetch from 'node-fetch';
 import { WA_URL, WA_USER_AGENT } from './constants';
 
 /**
+ * Return the alpha version declared inside of the page
+ * @param content HTML content of the page
+ * @returns Version number
+ */
+export function getAlphaVersionFromContent(content: string): string | null {
+  const matches = content.match(/"client_revision"\s*:\s*(\d+)/) || [];
+
+  if (matches[1]) {
+    return `2.3000.${matches[1]}-alpha`;
+  }
+
+  return null;
+}
+
+/**
  * Return the current active noraml version on WhatsApp WEB
  * @returns Version number
  */
@@ -36,11 +51,7 @@ export async function fetchCurrentAlphaVersion(): Promise<string | null> {
   const text = await response.text();
 
   if (text) {
-    const matches = text.match(/"client_revision"\s*:\s*(\d+)/) || [];
-
-    if (matches[1]) {
-      return `2.3000.${matches[1]}-alpha`;
-    }
+    return getAlphaVersionFromContent(text);
   }
 
   return null;

--- a/src/tools/update.ts
+++ b/src/tools/update.ts
@@ -261,6 +261,23 @@ async function updateJsonFile() {
 async function run() {
   const outdated = await checkActiveVersions();
   const newVersion = await updateLatest();
+
+  // The outdated files must be removed before updating versions.json,
+  // otherwise getAvailableVersions() still lists them and the removed
+  // versions remain in the file until the next execution
+  if (isCI && runCommit) {
+    for (const version of outdated) {
+      await execa('git', ['rm', getVersionPath(version)]);
+      const { stdout } = await execa('git', [
+        'commit',
+        '-m',
+        `fix: Removed outdated version: ${version}`,
+        getVersionPath(version),
+      ]);
+      process.stderr.write(`${stdout}\n`);
+    }
+  }
+
   const hasChanges = !!newVersion || !!outdated.length;
   const hasJsonChanges = await updateJsonFile();
 
@@ -271,19 +288,11 @@ async function run() {
     setGitHubState('version', newVersion);
     setGitHubState('hasChanges', hasChanges);
     setGitHubState('hasJsonChanges', hasJsonChanges);
+    // Only a new version triggers a release, the removal of outdated
+    // versions is published together with the next release
+    setGitHubState('shouldRelease', !!newVersion);
 
     if (runCommit) {
-      for (const version of outdated) {
-        await execa('git', ['rm', getVersionPath(version)]);
-        const { stdout } = await execa('git', [
-          'commit',
-          '-m',
-          `fix: Removed outdated version: ${version}`,
-          getVersionPath(version),
-        ]);
-        process.stderr.write(`${stdout}\n`);
-      }
-
       if (newVersion) {
         await execa('git', ['add', getVersionPath(newVersion)]);
         await execa('git', ['add', VERSIONS_FILE]);

--- a/src/tools/update.ts
+++ b/src/tools/update.ts
@@ -20,7 +20,10 @@ import * as os from 'os';
 import * as path from 'path';
 import { checkUpdate } from '../checkUpdate';
 import { HTML_DIR, VERSIONS_FILE } from '../constants';
-import { fetchCurrentAlphaVersion } from '../fetchCurrentAlphaVersion';
+import {
+  fetchCurrentAlphaVersion,
+  getAlphaVersionFromContent,
+} from '../fetchCurrentAlphaVersion';
 import { fetchCurrentBetaVersion } from '../fetchCurrentBetaVersion';
 import { fetchLatest } from '../fetchLatest';
 import { fetchLatestAlpha } from '../fetchLatestAlpha';
@@ -160,8 +163,7 @@ async function updateLatest() {
   // request can be answered with another build and generate a file named
   // with a revision that is not the one inside of it
   const alphaHtml = await fetchLatestAlpha();
-  const alphaMatches = alphaHtml.match(/"client_revision"\s*:\s*(\d+)/);
-  const alphaVersion = alphaMatches ? `2.3000.${alphaMatches[1]}-alpha` : null;
+  const alphaVersion = getAlphaVersionFromContent(alphaHtml);
 
   if (alphaVersion && !versions.includes(alphaVersion)) {
     process.stderr.write(`New version available: ${alphaVersion}\n`);

--- a/src/tools/update.ts
+++ b/src/tools/update.ts
@@ -156,24 +156,22 @@ async function updateLatest() {
     }
   }
 
-  const alphaVersion = await fetchCurrentAlphaVersion();
-  if (alphaVersion) {
-    // Check only part of version: 2.3000.1012058694-alpha -> 2.3000.101205
-    const hasNewVersion = versions
-      .map((v) => v.substring(0, 13))
-      .includes(alphaVersion.substring(0, 13));
+  // The version is read from the same response that is stored, a separated
+  // request can be answered with another build and generate a file named
+  // with a revision that is not the one inside of it
+  const alphaHtml = await fetchLatestAlpha();
+  const alphaMatches = alphaHtml.match(/"client_revision"\s*:\s*(\d+)/);
+  const alphaVersion = alphaMatches ? `2.3000.${alphaMatches[1]}-alpha` : null;
 
-    if (!hasNewVersion) {
-      process.stderr.write(`New version available: ${alphaVersion}\n`);
+  if (alphaVersion && !versions.includes(alphaVersion)) {
+    process.stderr.write(`New version available: ${alphaVersion}\n`);
 
-      process.stderr.write(`Generating new file\n`);
-      const html = await fetchLatestAlpha();
-      await fs.promises.writeFile(getVersionPath(alphaVersion), html, {
-        encoding: 'utf8',
-      });
-      process.stderr.write(`Done\n`);
-      return alphaVersion;
-    }
+    process.stderr.write(`Generating new file\n`);
+    await fs.promises.writeFile(getVersionPath(alphaVersion), alphaHtml, {
+      encoding: 'utf8',
+    });
+    process.stderr.write(`Done\n`);
+    return alphaVersion;
   }
 
   process.stderr.write(`is updated\n`);


### PR DESCRIPTION
## Problem

The repository was publishing around **8.2 releases per day**, and a good part of them did not correspond to a new WhatsApp Web build. At the same time, a large share of the real builds was **never stored**.

## What was fixed

### 1. The alpha version was read from a different request than the one stored

`fetchCurrentAlphaVersion()` got the `client_revision` in one request and `fetchLatestAlpha()` downloaded the page in another one. Between the two, a different build could be served, and the file was written under a number that is not the one inside of it.

Measured effect: **10 groups of stored pages have a duplicated internal `client_revision`**. For example, `html/2.3000.1045164762-alpha.html` contains the build `1045155773`.

It is a single request now, and the version comes from the same content that goes to disk.

### 2. The comparison truncated the version to 13 characters

```js
versions.map((v) => v.substring(0, 13)).includes(alphaVersion.substring(0, 13))
```

`2.3000.1045213319-alpha` became `2.3000.104521`, grouping the revisions in blocks of 10000. The original comment mentions `2.3000.1012058694`, from a time when the revision advanced ~1100 per build. Today it advances **~10400 per build**, so almost every build falls into a new block, and any one that fell into an already occupied block was silently discarded.

Rebuilding the history of the `currentAlpha` field of `versions.json`, which records the live revision even when nothing is stored:

| | |
|---|---|
| revisions served in the period covered by the current pages | 402 |
| never stored | **113 (28%)** |
| of those, colliding by block with an already stored version | **113 (100%)** |

The comparison now uses all the digits, the same way the stable and beta paths already did.

### 3. Removing a version generated a bump

`hasChanges = !!newVersion || !!outdated.length` enabled the release step, so deleting an expired version published a new version on npm. **47 of the last 139 releases did not add any HTML file.**

The `shouldRelease` output was added, and it is only true when there is a new version. The removal commits are pushed together with the next release that adds a version, since `release-it` pushes the whole branch.

Worth noting that the only expiration signal still working is the artificial one: the `check-update` endpoint answers `isBelowHard:false` and `currentVersion:"2.2413.51"` for any version, and the current pages no longer carry `hard_expire_time`. What is left is the `released + 2 months` from the script itself, which mirrors the rate of additions, and that is why the volume of removals followed the volume of additions.

The outdated Discord notification now follows `shouldRelease`, so it is not repeated on every execution while the release is pending.

### 4. `versions.json` was one cycle behind

`updateJsonFile()` ran before the `git rm`, so `getAvailableVersions()` still listed the file about to be deleted and the version stayed in the JSON. The repository currently has 304 entries for 303 files, the orphan being `2.3000.1041442250-alpha`, removed in 5a96ecd3.

The removal moved before the JSON update.

### 5. Hourly schedule

The `schedule` went from `5,35 * * * *` to `5 * * * *`. Since the workflow also runs on push to main and the checkout uses a personal token, the push made by `release-it` already starts an execution, covering the interval.

## Verification

- `tsc --noEmit`, `eslint src` and `prettier --check` clean.
- Two real runs of the script in sequence: the first stored `2.3000.1045220589-alpha` with `client_revision":1045220589` matching the file name; the second answered `is updated`, confirming the exact dedupe.
- A separate run confirming that, with the file already removed, `updateJsonFile()` drops the orphan entry from `versions.json`.

## Expected effect

From ~8.2 releases/day to ~7/day, without discarding 28% of the builds. The reduction is deliberately modest: part of what looked like noise was a legitimate build being lost.
