### PR TITLE
ci: hold conventional-changelog-angular on version 8

### DIFF
--- a/.github/renovate.json
+++ b/.github/renovate.json
@@ -49,6 +49,11 @@
       "description": "Ignore major version",
       "matchPackageNames": ["execa"],
       "allowedVersions": "<6"
+    },
+    {
+      "description": "Version 9 targets conventional-changelog-core 9, while conventional-changelog-cli bundles core 8, and the release entry comes out empty",
+      "matchPackageNames": ["conventional-changelog-angular"],
+      "allowedVersions": "<9"
     }
   ]
 }


### PR DESCRIPTION
#706 pinned `conventional-changelog-angular` to version 8 because version 9 targets `conventional-changelog-core` 9, while `conventional-changelog-cli` bundles core 8: the combination drops every commit without any error and the release entry comes out with the header only.

Renovate opened #707 to bump the package to v9 minutes after the merge. It is a major update, so it is not automerged, but the cap keeps it from landing by mistake and closes the open PR.

Same shape as the existing rules for `@types/node`, `node-fetch` and `execa`.