### PR TITLE
ci: trigger WA-JS compatibility checks on new versions

### DIFF
--- a/.github/workflows/wa-update.yml
+++ b/.github/workflows/wa-update.yml
@@ -9,7 +9,7 @@ on:
       - '*'
   workflow_dispatch:
   schedule:
-    - cron: '5 * * * *'
+    - cron: '5,35 * * * *'
 
 permissions:
   contents: read
@@ -99,3 +99,9 @@ jobs:
           description: |
             A new version of WhatsApp WEB has just been released.
             Version Number: `${{ fromJSON(steps.update.outputs.version) }}`
+
+      - name: Request immediate WA-JS compatibility check
+        if: ${{ steps.update.outputs.hasNewVersion == 'true' && github.event_name != 'pull_request' }}
+        run: gh workflow run compatibility-monitor.yml --repo wppconnect-team/wa-js -f trigger=wa-version
+        env:
+          GITHUB_TOKEN: ${{ secrets.PERSONAL_TOKEN }}


### PR DESCRIPTION
## Summary

- restore the WhatsApp version check cadence to every 30 minutes
- dispatch the WA-JS compatibility monitor immediately when a new version is detected
- keep pull requests read-only by dispatching only from non-PR runs

## Validation

- workflow YAML parsed
- workflow passed the repository Prettier configuration
- git diff --check

## Rollout dependency

Merge wppconnect-team/wa-js compatibility monitor first. The existing PERSONAL_TOKEN must have Actions write access to wa-js for cross-repository dispatch.